### PR TITLE
Import all valid CSV data as Tg Object

### DIFF
--- a/app/controllers/csv_uploads_controller.rb
+++ b/app/controllers/csv_uploads_controller.rb
@@ -17,6 +17,7 @@ class CsvUploadsController < ApplicationController
     @csv_upload = CsvUpload.new(csv_upload_params)
 
     if @csv_upload.save
+      CsvDataImporter.import(@csv_upload)
       redirect_to(root_path, notice: t("csv_upload.create.success"))
     end
   end

--- a/app/models/csv_data_importer.rb
+++ b/app/models/csv_data_importer.rb
@@ -1,0 +1,62 @@
+require "csv"
+require "open-uri"
+
+class CsvDataImporter
+  def initialize(csv_upload)
+    @failed_imports = []
+    @csv_upload = csv_upload
+  end
+
+  def import
+    import_objects_from_csv
+    update_csv_upload_status
+  end
+
+  def self.import(csv_upload)
+    new(csv_upload).import
+  end
+
+  private
+
+  attr_reader :csv_upload, :failed_imports
+
+  def import_objects_from_csv
+    CSV.new(open(csv_file_path), csv_options).each do |csv_row|
+      tg_object = create_tg_object_from_csv(csv_row)
+
+      unless tg_object.persisted?
+        csv_row[:errors] = tg_object.errors
+        @failed_imports.push(csv_row.to_h)
+      end
+    end
+  end
+
+  def update_csv_upload_status
+    if @failed_imports.empty?
+      csv_upload.update!(status: :imported)
+    else
+      csv_upload.update!(
+        status: :partially_imported,
+        failed_imports: @failed_imports,
+      )
+    end
+  end
+
+  def create_tg_object_from_csv(csv_row)
+    TgObject.create(
+      csv_upload: csv_upload,
+      timestamp: csv_row[:timestamp],
+      tg_object_id: csv_row[:object_id],
+      tg_object_type: csv_row[:object_type],
+      object_changes: csv_row[:object_changes],
+    )
+  end
+
+  def csv_options
+    { headers: true, header_converters: [:downcase, :symbol] }
+  end
+
+  def csv_file_path
+    Rails.env.test? ? csv_upload.csv_file.file.file : csv_upload.csv_file_url
+  end
+end

--- a/app/models/csv_upload.rb
+++ b/app/models/csv_upload.rb
@@ -1,5 +1,8 @@
 class CsvUpload < ApplicationRecord
   validates :csv_file, presence: true
+  has_many :tg_objects, dependent: :nullify
+  enum status: { pending: 0, partially_imported: 5, imported: 10 }
+
   mount_uploader :csv_file, CsvFileUploader
 
   def self.recent(limit = 100)

--- a/app/models/tg_object.rb
+++ b/app/models/tg_object.rb
@@ -1,0 +1,13 @@
+class TgObject < ApplicationRecord
+  belongs_to :csv_upload
+
+  validates :tg_object_id, :tg_object_type, presence: true
+  validates(
+    :timestamp,
+    presence: true,
+    uniqueness: {
+      scope: [:tg_object_id, :tg_object_type],
+      message: "duplicate entry for exact same object",
+    },
+  )
+end

--- a/app/views/csv_uploads/index.html.erb
+++ b/app/views/csv_uploads/index.html.erb
@@ -4,6 +4,7 @@
   <tr>
     <th>File Name</th>
     <th>Uploaded At</th>
+    <th>Status</th>
     <th>Download Link</th>
   </tr>
 
@@ -11,7 +12,8 @@
     <% @csv_uploads.each do |csv_upload| %>
       <tr>
         <td><%= csv_upload.csv_file.file.filename %></td>
-        <td><%=  csv_upload.created_at %></td>
+        <td><%= csv_upload.created_at %></td>
+        <td><%= csv_upload.status.humanize %></td>
         <td><%= link_to("Download", csv_upload.csv_file_url)%></td>
       </tr>
     <%  end %>

--- a/db/migrate/20170922081206_add_status_to_csv_upload.rb
+++ b/db/migrate/20170922081206_add_status_to_csv_upload.rb
@@ -1,0 +1,5 @@
+class AddStatusToCsvUpload < ActiveRecord::Migration[5.0]
+  def change
+    add_column :csv_uploads, :status, :integer, default: 0
+  end
+end

--- a/db/migrate/20170922100816_create_tg_objects.rb
+++ b/db/migrate/20170922100816_create_tg_objects.rb
@@ -1,0 +1,13 @@
+class CreateTgObjects < ActiveRecord::Migration[5.0]
+  def change
+    create_table :tg_objects do |t|
+      t.integer :tg_object_id, index: true
+      t.string :tg_object_type
+      t.integer :timestamp, index: true
+      t.jsonb :object_changes
+      t.references :csv_upload, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20170923052523_add_failed_imports_to_csv_upload.rb
+++ b/db/migrate/20170923052523_add_failed_imports_to_csv_upload.rb
@@ -1,0 +1,5 @@
+class AddFailedImportsToCsvUpload < ActiveRecord::Migration[5.0]
+  def change
+    add_column :csv_uploads, :failed_imports, :jsonb, default: {}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170921084626) do
+ActiveRecord::Schema.define(version: 20170923052523) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -18,8 +18,10 @@ ActiveRecord::Schema.define(version: 20170921084626) do
   create_table "csv_uploads", force: :cascade do |t|
     t.string   "tag"
     t.string   "csv_file"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at",                  null: false
+    t.datetime "updated_at",                  null: false
+    t.integer  "status",         default: 0
+    t.jsonb    "failed_imports", default: {}
   end
 
   create_table "delayed_jobs", force: :cascade do |t|
@@ -37,4 +39,16 @@ ActiveRecord::Schema.define(version: 20170921084626) do
     t.index ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
   end
 
+  create_table "tg_objects", force: :cascade do |t|
+    t.integer  "tg_object_id"
+    t.string   "tg_object_type"
+    t.integer  "timestamp"
+    t.jsonb    "object_changes"
+    t.integer  "csv_upload_id"
+    t.datetime "created_at",     null: false
+    t.datetime "updated_at",     null: false
+    t.index ["csv_upload_id"], name: "index_tg_objects_on_csv_upload_id", using: :btree
+  end
+
+  add_foreign_key "tg_objects", "csv_uploads"
 end

--- a/spec/controllers/csv_uploads_controller_spec.rb
+++ b/spec/controllers/csv_uploads_controller_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe CsvUploadsController, type: :controller do
+  describe "POST /csv_uploads" do
+    context "with valid data" do
+      it "creates a new upload and invoke import to importer" do
+        allow(CsvDataImporter).to receive(:import)
+
+        post(:create, params: { csv_upload: attributes_for(:csv_upload) })
+
+        expect(response).to redirect_to(root_path)
+        expect(flash[:notice]).to eq(t("csv_upload.create.success"))
+        expect(CsvDataImporter).to have_received(:import).with(CsvUpload.last)
+      end
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,8 +1,15 @@
 FactoryGirl.define do
+  factory :tg_object do
+    tg_object_id 1
+    tg_object_type "MyString"
+    timestamp 1
+    object_changes ""
+    csv_upload nil
+  end
   factory :csv_upload do
     csv_file do
       Rack::Test::UploadedFile.new(
-        File.join(Rails.root, "spec/fixtures/sample.csv")
+        Rails.root.join("spec", "fixtures", "sample.csv")
       )
     end
   end

--- a/spec/features/user_uploads_csv_file_spec.rb
+++ b/spec/features/user_uploads_csv_file_spec.rb
@@ -8,6 +8,7 @@ feature "User uploads a CSV file" do
     attach_file("CSV File", sample_csv_fixture_file)
     click_on "Upload"
 
+    expect(page).to have_content("Imported")
     expect(page).to have_content("sample.csv")
     expect(page).to have_content(I18n.t("csv_upload.create.success"))
   end

--- a/spec/fixtures/sample-partial.csv
+++ b/spec/fixtures/sample-partial.csv
@@ -1,0 +1,10 @@
+object_id,object_type,timestamp,object_changes
+1,Order,1484730554,"{ ""customer_name"": ""Jack"", ""customer_address"": ""Trade St."", ""status"": ""unpaid""}"
+2,Order,1484730623,"{""customer_name"":""Sam"",""customer_address"":""Gecko St."",""status"":""unpaid""}"
+1,Product,1484731172,"{""name"":""Laptop"",""price"":2100,""stock_levels"":29}"""
+1,Order,1484731481,"{""status"":""paid"",""ship_date"":""2017-01-18"",""shipping_provider"":""DHL""}"
+2,Product,1484731671,"{""name"":""Microphones"",""price"":160,""stock_levels"":1500}"""
+1,Invoice,1484731920,"{""order_id"":7,""product_ids"":[1,5,3],""status"":""unpaid"",""total"":2500}"
+1,Invoice,1484732821,"{""status"":""paid""}"""
+1,Invoice,1484732821,"{""status"":""paid""}"""
+,Invoice,1484732821,"{""status"":""paid""}"""

--- a/spec/models/csv_data_importer_spec.rb
+++ b/spec/models/csv_data_importer_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe CsvDataImporter do
+  describe ".import" do
+    context "with valid data" do
+      it "importes csv data successfully" do
+        csv_upload = create(:csv_upload)
+
+        CsvDataImporter.import(csv_upload)
+
+        expect(csv_upload.status).to eq("imported")
+        expect(csv_upload.tg_objects.count).to eq(7)
+      end
+    end
+
+    context "with some invalid data" do
+      it "partially import the valid csv data" do
+        csv_upload = create_upload_with_partial_valid_data
+
+        CsvDataImporter.import(csv_upload)
+
+        expect(csv_upload.tg_objects.count).to eq(7)
+        expect(csv_upload.status).to eq("partially_imported")
+        expect(csv_upload.failed_imports.first["errors"]["timestamp"]).
+          to(match_array(["duplicate entry for exact same object"]))
+      end
+    end
+  end
+
+  def create_upload_with_partial_valid_data
+    create(
+      :csv_upload,
+      csv_file: Rack::Test::UploadedFile.new(
+        Rails.root.join("spec", "fixtures", "sample-partial.csv")
+      )
+    )
+  end
+end

--- a/spec/models/tg_object_spec.rb
+++ b/spec/models/tg_object_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe TgObject, type: :model do
+  describe "validations" do
+    it { should validate_presence_of :tg_object_id }
+    it { should validate_presence_of :tg_object_type }
+    it { should validate_presence_of :timestamp }
+
+    it "ensures unique timestamp entry scopped to object and type " do
+      should(
+        validate_uniqueness_of(:timestamp).
+        scoped_to(:tg_object_id, :tg_object_type).
+        with_message("duplicate entry for exact same object")
+      )
+    end
+  end
+end


### PR DESCRIPTION
In the previous commit, we've added the functionality to upload a CSV file and the next step is to process and store those data properly. But before importing those data here are the some of the major considerations.

The happiest path, a user uploads a CSV with all of the valid data and in that case, it is safe to import those data and update the CSV file status to `imported`.

Second consideration, user might upload a CSV file with partial valid data with some invalidate or duplicate entry, and in that case, we might import the valid entry but also keep track of the invalid entry so later we might also offer the user to download those data and fix those validation errors and re-upload.

And this commit considers those above scenarios & add the changes to import user uploaded data properly with the tracking option for those invalid entry.

Future Improvements:

In this current version, we are reading a file from a remote io and it should work fine for our purpose for now, but if it does any harm on performance then we might consider downloading the file first and then do the CSV parsing.