### PR TITLE
Optimizing CSV data importing procedure

### DIFF
--- a/app/controllers/csv_uploads_controller.rb
+++ b/app/controllers/csv_uploads_controller.rb
@@ -17,8 +17,8 @@ class CsvUploadsController < ApplicationController
     @csv_upload = CsvUpload.new(csv_upload_params)
 
     if @csv_upload.save
-      CsvDataImporter.import(@csv_upload)
-      redirect_to(root_path, notice: t("csv_upload.create.success"))
+      CsvDataImporterJob.perform_later(@csv_upload)
+      redirect_to(root_path, notice: t("csv_uploads.create.success"))
     end
   end
 

--- a/app/jobs/csv_data_importer_job.rb
+++ b/app/jobs/csv_data_importer_job.rb
@@ -1,0 +1,5 @@
+class CsvDataImporterJob < ApplicationJob
+  def perform(csv_upload)
+    CsvDataImporter.import(csv_upload)
+  end
+end

--- a/app/models/csv_data_importer.rb
+++ b/app/models/csv_data_importer.rb
@@ -51,6 +51,8 @@ class CsvDataImporter
       tg_object_type: csv_row[:object_type],
       object_changes: JSON.parse(csv_row[:object_changes]),
     )
+  rescue JSON::ParserError
+    TgObject.new { |object| object.errors.add(:object_changes, "Invalid JSON") }
   end
 
   def csv_options

--- a/app/views/csv_uploads/new.html.erb
+++ b/app/views/csv_uploads/new.html.erb
@@ -2,7 +2,7 @@
 
 <div class="col-md-6 top10">
   <%= simple_form_for @csv_upload do |form| %>
-    <%= form.input :csv_file, label: "CSV File" %>
+    <%= form.input :csv_file, label: "CSV File", hint: t(".csv_hint") %>
     <%= form.input :tag %>
     <%= form.button :submit, "Upload" %>
   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -18,6 +18,11 @@ en:
   titles:
     application: State tracker
 
-  csv_upload:
+  csv_uploads:
+    new:
+      csv_hint:
+        "Please use object_id, object_type, timestamp and object_changes
+        as header title"
+
     create:
-      success: "Successfully created!"
+      success: "Upload created, we've enqueued a job to import those data!"

--- a/spec/controllers/csv_uploads_controller_spec.rb
+++ b/spec/controllers/csv_uploads_controller_spec.rb
@@ -3,14 +3,18 @@ require "rails_helper"
 RSpec.describe CsvUploadsController, type: :controller do
   describe "POST /csv_uploads" do
     context "with valid data" do
-      it "creates a new upload and invoke import to importer" do
+      it "creates a new upload and enqueue an import job" do
+        allow(CsvDataImporterJob).to receive(:perform_later)
         allow(CsvDataImporter).to receive(:import)
 
         post(:create, params: { csv_upload: attributes_for(:csv_upload) })
 
+        expect(
+          CsvDataImporterJob,
+        ).to have_received(:perform_later).with(CsvUpload.last)
+
         expect(response).to redirect_to(root_path)
-        expect(flash[:notice]).to eq(t("csv_upload.create.success"))
-        expect(CsvDataImporter).to have_received(:import).with(CsvUpload.last)
+        expect(flash[:notice]).to eq(t("csv_uploads.create.success"))
       end
     end
   end

--- a/spec/features/user_uploads_a_csv_data_file_spec.rb
+++ b/spec/features/user_uploads_a_csv_data_file_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
-feature "User uploads a CSV file" do
-  scenario "creates a new upload with valid data" do
+feature "Uploading a CSV" do
+  scenario "with valid info imports the data properly" do
     visit root_path
     click_on "Upload A CSV"
 
@@ -10,10 +10,10 @@ feature "User uploads a CSV file" do
 
     expect(page).to have_content("Imported")
     expect(page).to have_content("sample.csv")
-    expect(page).to have_content(I18n.t("csv_upload.create.success"))
+    expect(page).to have_content(I18n.t("csv_uploads.create.success"))
   end
 
-  scenario "does not create a upload with invalid data" do
+  scenario "with invalid data does not import anything" do
     visit root_path
     click_on "Upload A CSV"
 

--- a/spec/fixtures/sample-partial.csv
+++ b/spec/fixtures/sample-partial.csv
@@ -8,3 +8,4 @@ object_id,object_type,timestamp,object_changes
 1,Invoice,1484732821,"{""status"":""paid""}"
 1,Invoice,1484732821,"{""status"":""paid""}"
 ,Invoice,1484732821,"{""status"":""paid""}"
+121,Invoice,1484732821,"{""status"":""paid""}"""

--- a/spec/jobs/csv_data_importer_job_spec.rb
+++ b/spec/jobs/csv_data_importer_job_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.describe CsvDataImporterJob do
+  describe "#perform" do
+    it "invokes import method to data importer" do
+      csv_upload = create(:csv_upload)
+      allow(CsvDataImporter).to receive(:import)
+
+      CsvDataImporterJob.perform_now(csv_upload)
+
+      expect(CsvDataImporter).to have_received(:import).with(csv_upload)
+    end
+  end
+end

--- a/spec/models/csv_data_importer_spec.rb
+++ b/spec/models/csv_data_importer_spec.rb
@@ -21,8 +21,13 @@ RSpec.describe CsvDataImporter do
 
         expect(csv_upload.tg_objects.count).to eq(7)
         expect(csv_upload.status).to eq("partially_imported")
+
         expect(csv_upload.failed_imports.first["errors"]["timestamp"]).
           to(match_array(["duplicate entry for exact same object"]))
+
+        expect(
+          csv_upload.failed_imports.last["errors"]["object_changes"],
+        ).to(match_array(["Invalid JSON"]))
       end
     end
   end


### PR DESCRIPTION
Currently, we are trying to process the CSV data instantly, which is not ideal for a large sets of data, and we are also not doing any kind of validation for the json data, which might introduce some problem in the long run.

This commit takes those into consideration and create a process to send the data parsing work in the background, and it also add some parsing level validation to ensure we only store valid data

To keep the scope small we're not doing any validation in regards to the csv file and data structure in it, so that's something we can do as a future improvement to this application.