### PR TITLE
Optimize JSON aggregation related SQL Query

### DIFF
--- a/app/models/tg_object.rb
+++ b/app/models/tg_object.rb
@@ -11,15 +11,9 @@ class TgObject < ApplicationRecord
     },
   )
 
-  def self.find_status(tg_object_id, tg_object_type, timestamp)
-    select("jsonb_object_agg(object_changes) as status").
-      from(TgObject.find_changes(tg_object_id, tg_object_type, timestamp)).
-      take.status
-  end
-
-  def self.find_changes(tg_object_id, tg_object_type, timestamp = nil)
-    where(tg_object_id: tg_object_id, tg_object_type: tg_object_type).
-      where("timestamp <= ?", (timestamp || Time.now).to_i).
-      order(timestamp: :asc)
+  def self.find_status(tg_object_id, tg_object_type, timestamp = nil)
+    select("jsonb_object_agg(object_changes order by timestamp asc) as status").
+      where(tg_object_id: tg_object_id, tg_object_type: tg_object_type).
+      where("timestamp <= ?", (timestamp || Time.now).to_i).take.status
   end
 end

--- a/spec/models/tg_object_spec.rb
+++ b/spec/models/tg_object_spec.rb
@@ -39,18 +39,6 @@ RSpec.describe TgObject, type: :model do
     end
   end
 
-  describe ".find_changes" do
-    it "returns all changes for an object" do
-      old = create_tg_object(1, 10, status: "paid")
-      second_old = create_tg_object(1, 8, status: "unpaid")
-      _other = create_tg_object(1, 5, { status: "unknown" }, "Product")
-
-      expect(
-        TgObject.find_changes(1, "Order", Time.now.to_i).map(&:id),
-      ).to eq([old.id, second_old.id])
-    end
-  end
-
   def create_tg_object(id, minutes, object_changes, object_type = "Order")
     create(
       :tg_object,


### PR DESCRIPTION
In the `TgObject` model we have an interface that does the job to aggregate the object changes and finally we show that to the user

In the underneath we're running sub-query to sort those changes and then pass it to the aggregation function. This is probably fine and might not effect anything at all.

But looking at the query plan it seems like there is a better a way to do it and that's what we've implemented in this query.