### PR TITLE
Add support for non-standard csv format

### DIFF
--- a/app/models/csv_data_importer.rb
+++ b/app/models/csv_data_importer.rb
@@ -11,6 +11,8 @@ class CsvDataImporter
   def import
     import_objects_from_csv
     update_csv_upload_status
+  rescue CSV::MalformedCSVError
+    csv_upload.update(status: :invalid_format)
   end
 
   def self.import(csv_upload)

--- a/app/models/csv_upload.rb
+++ b/app/models/csv_upload.rb
@@ -1,9 +1,16 @@
 class CsvUpload < ApplicationRecord
   validates :csv_file, presence: true
   has_many :tg_objects, dependent: :nullify
-  enum status: { pending: 0, partially_imported: 5, imported: 10 }
-
   mount_uploader :csv_file, CsvFileUploader
+
+  enum(
+    status: {
+      pending: 0,
+      imported: 10,
+      invalid_format: 20,
+      partially_imported: 5,
+    },
+  )
 
   def self.recent(limit = 100)
     order(created_at: :desc).limit(limit)

--- a/spec/fixtures/invalid-format.csv
+++ b/spec/fixtures/invalid-format.csv
@@ -1,0 +1,3 @@
+object_id,object_type,timestamp,object_changes
+17950151,Order,1489688604,"{"status":"void"}"
+11226550,Company,1489688605,"{"name":"Chris springs"}"

--- a/spec/fixtures/sample-with-backslash-quote.csv
+++ b/spec/fixtures/sample-with-backslash-quote.csv
@@ -1,0 +1,3 @@
+object_id,object_type,timestamp,object_changes
+17950151,Order,1489688604,"{\"status\":\"void\",\"name\":\"kuddus\"}"
+11226550,Company,1489688605,"{\"name\":\"Chris springs\"}"

--- a/spec/models/csv_data_importer_spec.rb
+++ b/spec/models/csv_data_importer_spec.rb
@@ -13,6 +13,19 @@ RSpec.describe CsvDataImporter do
       end
     end
 
+    context "csv data with backslash" do
+      it "formats and imports data successfully" do
+        csv_upload = create_upload_with_fixture("sample-with-backslash-quote")
+
+        CsvDataImporter.import(csv_upload)
+        tg_objects = csv_upload.tg_objects
+
+        expect(tg_objects.count).to eq(2)
+        expect(csv_upload.status).to eq("imported")
+        expect(tg_objects.last.object_changes["name"]).to eq("Chris springs")
+      end
+    end
+
     context "with some invalid data" do
       it "partially import the valid csv data" do
         csv_upload = create_upload_with_partial_valid_data
@@ -33,10 +46,14 @@ RSpec.describe CsvDataImporter do
   end
 
   def create_upload_with_partial_valid_data
+    create_upload_with_fixture("sample-partial")
+  end
+
+  def create_upload_with_fixture(csv_filename, ext = "csv")
     create(
       :csv_upload,
       csv_file: Rack::Test::UploadedFile.new(
-        Rails.root.join("spec", "fixtures", "sample-partial.csv")
+        Rails.root.join("spec", "fixtures", [csv_filename, ext].join("."))
       )
     )
   end

--- a/spec/models/csv_data_importer_spec.rb
+++ b/spec/models/csv_data_importer_spec.rb
@@ -43,6 +43,17 @@ RSpec.describe CsvDataImporter do
         ).to(match_array(["Invalid JSON"]))
       end
     end
+
+    context "with invalid csv data" do
+      it "marks the csv upload as invalid format" do
+        csv_upload = create_upload_with_fixture("invalid-format")
+
+        CsvDataImporter.import(csv_upload)
+
+        expect(csv_upload.tg_objects.count).to eq(0)
+        expect(csv_upload.status).to eq("invalid_format")
+      end
+    end
   end
 
   def create_upload_with_partial_valid_data


### PR DESCRIPTION
Base on the RFC standard double quotes should be escaped by preceding double quotes, but based on the provided sample looks like we have some non-standard format to represent the changes of an object as a json string.

Ideally, it might be a good idea to avoid this, as most of the common tools won't have direct support for this type of format, but if that's what we need to support then this PR might come in handy.

A couple of consideration here though, before parsing we might replace those `\"` with the proper format, but that might be a performance issue for the bigger file.

Another approach could change the `quote_char` something else so the CSV parser does not throw any error instantly, and then manually unescape those object changes, but this will add some limitations.

So, considering both of the scenarios, the first one seems more suitable, and that's what we have implemented here, so if this what we want then please feel free to merge this PR.

Reference: https://tools.ietf.org/html/rfc4180#section-2